### PR TITLE
Secure API endpoints with token authentication

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,8 +1,10 @@
 from django.shortcuts import render
 
 from rest_framework import viewsets, generics
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.response import Response
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
 from datetime import date, timedelta
 
 from .models import Apartment, Tenant, Lease, MaintenanceRequest
@@ -13,20 +15,30 @@ from .serializers import (
 class ApartmentViewSet(viewsets.ModelViewSet):
     queryset = Apartment.objects.all()
     serializer_class = ApartmentSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
 class TenantViewSet(viewsets.ModelViewSet):
     queryset = Tenant.objects.all()
     serializer_class = TenantSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
 class LeaseViewSet(viewsets.ModelViewSet):
     queryset = Lease.objects.all()
     serializer_class = LeaseSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
 class MaintenanceRequestViewSet(viewsets.ModelViewSet):
     queryset = MaintenanceRequest.objects.all()
     serializer_class = MaintenanceRequestSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
 @api_view(['GET'])
+@authentication_classes([TokenAuthentication])
+@permission_classes([IsAuthenticated])
 def overview(request):
     total = Apartment.objects.count()
     occupied = Apartment.objects.filter(status='occupied').count()
@@ -54,6 +66,8 @@ def overview(request):
 
 class UpcomingMoveInsView(generics.ListAPIView):
     serializer_class = LeaseSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     def get_queryset(self):
         today = date.today()
         next_week = today + timedelta(days=7)
@@ -61,6 +75,8 @@ class UpcomingMoveInsView(generics.ListAPIView):
 
 class UpcomingMoveOutsView(generics.ListAPIView):
     serializer_class = LeaseSerializer
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
     def get_queryset(self):
         today = date.today()
         next_week = today + timedelta(days=7)

--- a/propertymgmt/settings.py
+++ b/propertymgmt/settings.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
+    "rest_framework.authtoken",
     "core",
 ]
 
@@ -102,3 +103,14 @@ STATIC_URL = "static/"
 
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Django REST Framework global settings
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+}

--- a/propertymgmt/urls.py
+++ b/propertymgmt/urls.py
@@ -1,8 +1,10 @@
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/token/", obtain_auth_token, name="api-token"),
     path('api/', include('core.urls')),
 ]
 


### PR DESCRIPTION
## Summary
- enable DRF token auth and default permission settings
- expose `/api/token/` endpoint for obtaining auth tokens
- require token authentication and IsAuthenticated across all API views

## Testing
- `python -m pytest`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_6892691f844883218321afb24b6e2c9e